### PR TITLE
Sync nfs image from k8s.gcr.io to dockerhub for domestic users

### DIFF
--- a/rules/dockerhub/storage.yaml
+++ b/rules/dockerhub/storage.yaml
@@ -1,0 +1,2 @@
+# used by https://github.com/kubesphere/helm-charts/tree/master/src/main/nfs-client-provisioner for domestic environment
+"k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner": "kubesphere/nfs-subdir-external-provisioner"


### PR DESCRIPTION
Signed-off-by: dkven <dkvvven@gmail.com>

Refer to this PR:
https://github.com/kubesphere/helm-charts/pull/145