### PR TITLE
Sync snapshot-controller image to aliyun

### DIFF
--- a/rules/aliyun/storage.yaml
+++ b/rules/aliyun/storage.yaml
@@ -6,6 +6,7 @@
 "csiplugin/csi-attacher": "registry.cn-beijing.aliyuncs.com/kubesphereio/csi-attacher"
 "csiplugin/csi-resizer": "registry.cn-beijing.aliyuncs.com/kubesphereio/csi-resizer"
 "csiplugin/csi-snapshotter": "registry.cn-beijing.aliyuncs.com/kubesphereio/csi-snapshotter"
+"k8s.gcr.io/sig-storage/snapshot-controller": "registry.cn-beijing.aliyuncs.com/kubesphereio/snapshot-controller"
 "csiplugin/csi-node-driver-registrar": "registry.cn-beijing.aliyuncs.com/kubesphereio/csi-node-driver-registrar"
 "csiplugin/csi-qingcloud": "registry.cn-beijing.aliyuncs.com/kubesphereio/csi-qingcloud"
 


### PR DESCRIPTION
Signed-off-by: dkeven <keven@kubesphere.io>

Currently, the image repo `registry.cn-beijing.aliyuncs.com/kubesphereio/snapshot-controller` has only some static old tags, which will result in mainland Chinese users failing to install KS v3.2 because this image has been upgraded.