### PR TITLE
Sync pvc-autoresizer image to dockerhub

### DIFF
--- a/rules/custom2kubespheredev/pvc-autoresizer.yaml
+++ b/rules/custom2kubespheredev/pvc-autoresizer.yaml
@@ -1,0 +1,2 @@
+# used by  https://github.com/kubesphere/pvc-autoresizer
+"f10atin9/pvc-autoresizer": "kubesphere/pvc-autoresizer"


### PR DESCRIPTION
Signed-off-by: f10atin9 <f10atin9@kubesphere.io>

In the helm-charts of pvc-autoresizer, the repo address needs to be kubesphere/pvc-autoresizer.